### PR TITLE
Switch to scala 2.11.8; Fixed imports for build.sbt; Updated to new eclipse plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,14 @@
+import org.fusesource.scalate.ScalatePlugin.ScalateKeys.scalateTemplateConfig
+import org.fusesource.scalate.ScalatePlugin.TemplateConfig
+import org.fusesource.scalate.ScalatePlugin.Binding
+import org.fusesource.scalate.ScalatePlugin.scalateSettings
+
 organization := "tv.cntt"
 name         := "xitrum-new"
 version      := "1.0-SNAPSHOT"
 
-scalaVersion := "2.12.1"
-scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked")
+scalaVersion := "2.11.8"
+scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-target:jvm-1.8")
 
 // Xitrum requires Java 8
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
@@ -26,7 +31,7 @@ libraryDependencies += "tv.cntt" %% "xitrum-scalate" % "2.7.1"
 
 // Precompile Scalate templates
 Seq(scalateSettings:_*)
-ScalateKeys.scalateTemplateConfig in Compile := Seq(TemplateConfig(
+scalateTemplateConfig in Compile := Seq(TemplateConfig(
   baseDirectory.value / "src" / "main" / "scalate",
   Seq(),
   Seq(Binding("helper", "xitrum.Action", importMembers = true))
@@ -46,5 +51,10 @@ unmanagedClasspath in Compile += Attributed.blank(baseDirectory.value / "config"
 // For "sbt run"
 unmanagedClasspath in Runtime += Attributed.blank(baseDirectory.value / "config")
 
+// For "sbt eclipse"
+EclipseKeys.executionEnvironment := Some(EclipseExecutionEnvironment.JavaSE18)
+EclipseKeys.configurations := Set(Compile, Runtime)
+
 // Copy these to target/xitrum when sbt xitrum-package is run
 XitrumPackage.copy("config", "public", "script")
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // Run sbt eclipse to create Eclipse project file
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.3.0")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.1.0")
 
 // Run sbt xitrum-package to prepare for deploying to production environment
 addSbtPlugin("tv.cntt" % "xitrum-package" % "1.9")


### PR DESCRIPTION
Switch to scala 2.11.8 (Scala IDE currently not supported 2.12); Fixed imports for build.sbt; Updated to new eclipse plugin